### PR TITLE
Update to Minecraft 1.16.5

### DIFF
--- a/redcraft_plugins.json
+++ b/redcraft_plugins.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "Yatopia",
-        "url": "https://ci.codemc.io/job/YatopiaMC/job/Yatopia/job/ver%252F1.16.4/",
+        "url": "https://ci.codemc.io/job/YatopiaMC/job/Yatopia/job/ver%252F1.16.5/",
         "source": "jenkins",
         "post_processors": ["paperclip"],
         "filter": "yatopia-*.jar"


### PR DESCRIPTION
This makes sure to have Yatopia 1.16.5 in our repository for Minecraft 1.16.5