### PR TITLE
Update for 1.17

### DIFF
--- a/download/sources/papermc_source.py
+++ b/download/sources/papermc_source.py
@@ -19,11 +19,8 @@ class PapermcSource(DirectSource):
 
         last_build = papermc_response["builds"][-1]
 
-        print(last_build)
-
         download = last_build["downloads"]["application"]
         # Find and return the file from the build
-        print(download)
         name = download["name"]
         if filter_regex.match(name):
             artifact_url = "{}/{}/downloads/{}".format(

--- a/download/sources/spigotmc_source.py
+++ b/download/sources/spigotmc_source.py
@@ -16,7 +16,7 @@ class SpigotmcSource(DirectSource):
     base_url = "https://www.spigotmc.org"
 
     # Needs to be a popular plugin with an external download
-    plugin_to_escalate_token = "https://www.spigotmc.org/resources/fast-async-worldedit-voxelsniper.13932/download?version=320370"
+    plugin_to_escalate_token = "https://www.spigotmc.org/resources/authmereloaded.6269/download?version=392191"
 
     session = None
     logout_url = None

--- a/redcraft_plugins.json
+++ b/redcraft_plugins.json
@@ -1,23 +1,27 @@
 [
     {
-        "name": "Yatopia",
-        "url": "https://ci.codemc.io/job/YatopiaMC/job/Yatopia/job/ver%252F1.16.5/",
+        "name": "Airplane",
+        "url": "https://ci.tivy.ca/job/Airplane-1.17/",
         "source": "jenkins",
-        "post_processors": ["paperclip"],
-        "filter": "yatopia-*.jar"
+        "post_processors": [
+            "paperclip"
+        ],
+        "filter": "launcher-airplane.jar"
     },
     {
         "name": "Waterfall.jar",
-        "url": "https://papermc.io/api/v2/projects/waterfall/version_group/1.16/builds",
+        "url": "https://papermc.io/api/v2/projects/waterfall/version_group/1.17/builds",
         "source": "papermc",
         "post_processors": [],
-        "filter": "waterfall-1.16-*.jar"
+        "filter": "waterfall-1.17-*.jar"
     },
     {
         "name": "CMI",
         "url": "https://www.spigotmc.org/resources/cmi-270-commands-insane-kits-portals-essentials-economy-mysql-sqlite-much-more.3742/",
         "source": "spigotmc",
-        "post_processors": ["plugin"]
+        "post_processors": [
+            "plugin"
+        ]
     },
     {
         "name": "CoreProtect",
@@ -31,174 +35,230 @@
         "name": "Panilla",
         "url": "https://www.spigotmc.org/resources/panilla-prevent-hacked-items.65694/",
         "source": "spigotmc",
-        "post_processors": ["plugin"]
+        "post_processors": [
+            "plugin"
+        ]
     },
     {
         "name": "Head Database",
         "url": "https://www.spigotmc.org/resources/head-database.14280/",
         "source": "spigotmc",
-        "post_processors": ["plugin"]
+        "post_processors": [
+            "plugin"
+        ]
     },
     {
         "name": "AAC",
         "url": "https://www.spigotmc.org/resources/aac-advanced-anti-cheat-hack-kill-aura-blocker.6442/",
         "source": "spigotmc",
-        "post_processors": ["plugin"]
+        "post_processors": [
+            "plugin"
+        ]
     },
     {
         "name": "Reconnect",
         "url": "https://www.spigotmc.org/resources/bungee-reconnect.16429/",
         "source": "spigotmc",
-        "post_processors": ["plugin"]
+        "post_processors": [
+            "plugin"
+        ]
     },
     {
         "name": "LiteBans",
         "url": "https://www.spigotmc.org/resources/litebans.3715/",
         "source": "spigotmc",
-        "post_processors": ["plugin"]
+        "post_processors": [
+            "plugin"
+        ]
     },
     {
         "name": "goPaint",
         "url": "https://www.spigotmc.org/resources/gopaint.27717/",
         "source": "spigotmc",
-        "post_processors": ["zip", "plugin"],
+        "post_processors": [
+            "zip",
+            "plugin"
+        ],
         "archive_filter": "goPaint 1.14*.jar"
     },
     {
         "name": "goBrush",
         "url": "https://www.spigotmc.org/resources/gobrush.23118/",
         "source": "spigotmc",
-        "post_processors": ["zip", "plugin"],
+        "post_processors": [
+            "zip",
+            "plugin"
+        ],
         "archive_filter": "goBrush 1.14*.jar"
     },
     {
         "name": "FarmLimiter",
         "url": "https://www.spigotmc.org/resources/farm-limiter.1419/",
         "source": "spigotmc",
-        "post_processors": ["plugin"]
+        "post_processors": [
+            "plugin"
+        ]
     },
     {
         "name": "SelectionVisualizer",
         "url": "https://www.spigotmc.org/resources/selection-visualizer.22631/",
         "source": "spigotmc",
-        "post_processors": ["plugin"]
+        "post_processors": [
+            "plugin"
+        ]
     },
     {
         "name": "PlotSquared",
         "url": "https://www.spigotmc.org/resources/plotsquared-v5.77506/",
         "source": "spigotmc",
-        "post_processors": ["plugin"]
+        "post_processors": [
+            "plugin"
+        ]
     },
     {
         "name": "EpicWorldGenerator",
         "url": "https://www.spigotmc.org/resources/epicworldgenerator-1-15-1-16-4-%E2%9D%97%EF%B8%8Fsale-%E2%9D%97%EF%B8%8F-20-off.8067/",
         "source": "spigotmc",
-        "post_processors": ["plugin"]
+        "post_processors": [
+            "plugin"
+        ]
     },
     {
         "name": "ClientStats",
         "url": "https://www.spigotmc.org/resources/clientstats-bungee.27919/",
         "source": "spigotmc",
-        "post_processors": ["plugin"]
+        "post_processors": [
+            "plugin"
+        ]
     },
     {
         "name": "RedstoneClockDetector",
         "url": "https://www.spigotmc.org/resources/redstoneclockdetector.18475/",
         "source": "spigotmc",
-        "post_processors": ["plugin"]
+        "post_processors": [
+            "plugin"
+        ]
     },
     {
         "name": "BungeePluginManager",
         "url": "https://www.spigotmc.org/resources/bungeepluginmanager.7288/",
         "source": "spigotmc",
-        "post_processors": ["plugin"]
+        "post_processors": [
+            "plugin"
+        ]
     },
     {
         "name": "WorldBorder",
         "url": "https://www.spigotmc.org/resources/worldborder-1-15.80466/",
         "source": "spigotmc",
-        "post_processors": ["plugin"]
+        "post_processors": [
+            "plugin"
+        ]
     },
     {
         "name": "F3NPerm",
         "url": "https://www.spigotmc.org/resources/f3nperm.46461/",
         "source": "spigotmc",
-        "post_processors": ["plugin"]
+        "post_processors": [
+            "plugin"
+        ]
     },
     {
         "name": "BookExploitFix",
         "url": "https://www.spigotmc.org/resources/bookexploitfix.5897/",
         "source": "spigotmc",
-        "post_processors": ["plugin"]
+        "post_processors": [
+            "plugin"
+        ]
     },
     {
         "name": "ServerListPlus",
         "url": "https://ci.codemc.io/job/Minecrell/job/ServerListPlus/",
         "source": "jenkins",
-        "post_processors": ["plugin"],
+        "post_processors": [
+            "plugin"
+        ],
         "filter": "ServerListPlus-*-Universal.jar"
     },
     {
         "name": "FastAsyncWorldEdit",
-        "url": "https://ci.athion.net/job/FastAsyncWorldEdit-1.16/",
+        "url": "https://ci.athion.net/job/FastAsyncWorldEdit-1.17/",
         "source": "jenkins",
-        "post_processors": ["plugin"],
-        "filter": "FastAsyncWorldEdit-Bukkit-1.16-*.jar"
+        "post_processors": [
+            "plugin"
+        ],
+        "filter": "FastAsyncWorldEdit-Bukkit-1.17-*.jar"
     },
     {
         "name": "ViaVersion",
         "url": "https://ci.viaversion.com/job/ViaVersion/",
         "source": "jenkins",
-        "post_processors": ["plugin"],
+        "post_processors": [
+            "plugin"
+        ],
         "filter": "ViaVersion-*.jar"
     },
     {
         "name": "spark",
         "url": "https://ci.lucko.me/job/spark/",
         "source": "jenkins",
-        "post_processors": ["plugin"],
+        "post_processors": [
+            "plugin"
+        ],
         "filter": "spark.jar"
     },
     {
         "name": "LuckPerms",
         "url": "https://ci.lucko.me/job/LuckPerms/",
         "source": "jenkins",
-        "post_processors": ["plugin"],
+        "post_processors": [
+            "plugin"
+        ],
         "filter": "LuckPerms-Bukkit-*.jar"
     },
     {
         "name": "LuckPermsBungee",
         "url": "https://ci.lucko.me/job/LuckPerms/",
         "source": "jenkins",
-        "post_processors": ["plugin"],
+        "post_processors": [
+            "plugin"
+        ],
         "filter": "LuckPerms-Bungee-*.jar"
     },
     {
         "name": "BungeeTabListPlus",
         "url": "https://ci.codecrafter47.de/job/BungeeTabListPlus/",
         "source": "jenkins",
-        "post_processors": ["plugin"],
+        "post_processors": [
+            "plugin"
+        ],
         "filter": "BungeeTabListPlus-*.jar"
     },
     {
         "name": "BungeeTabListPlusBridge",
         "url": "https://ci.codecrafter47.de/job/BungeeTabListPlus/",
         "source": "jenkins",
-        "post_processors": ["plugin"],
+        "post_processors": [
+            "plugin"
+        ],
         "filter": "BungeeTabListPlus_BukkitBridge-*.jar"
     },
     {
         "name": "RedCraftReboot",
         "url": "https://github.com/redcraft-org/RedCraftReboot",
         "source": "github",
-        "post_processors": ["plugin"],
+        "post_processors": [
+            "plugin"
+        ],
         "filter": "RedCraftReboot-*.jar"
     },
     {
         "name": "RedCraftBungeeJsonApi",
         "url": "https://github.com/redcraft-org/RedCraftBungeeJsonApi",
         "source": "github",
-        "post_processors": ["plugin"],
+        "post_processors": [
+            "plugin"
+        ],
         "filter": "RedCraftBungeeJsonApi-*.jar"
     }
 ]

--- a/redcraft_plugins.json
+++ b/redcraft_plugins.json
@@ -9,7 +9,7 @@
         "filter": "launcher-airplane.jar"
     },
     {
-        "name": "Waterfall.jar",
+        "name": "Waterfall 1.17.jar",
         "url": "https://papermc.io/api/v2/projects/waterfall/version_group/1.17/builds",
         "source": "papermc",
         "post_processors": [],
@@ -73,23 +73,21 @@
     },
     {
         "name": "goPaint",
-        "url": "https://www.spigotmc.org/resources/gopaint.27717/",
-        "source": "spigotmc",
+        "url": "https://ci.athion.net/job/goPaint-1.14+/",
+        "source": "jenkins",
         "post_processors": [
-            "zip",
             "plugin"
         ],
-        "archive_filter": "goPaint 1.14*.jar"
+        "filter": "goPaint-*.jar"
     },
     {
         "name": "goBrush",
-        "url": "https://www.spigotmc.org/resources/gobrush.23118/",
-        "source": "spigotmc",
+        "url": "https://ci.athion.net/job/goBrush-1.13+/",
+        "source": "jenkins",
         "post_processors": [
-            "zip",
             "plugin"
         ],
-        "archive_filter": "goBrush 1.14*.jar"
+        "filter": "goBrush-*.jar"
     },
     {
         "name": "FarmLimiter",


### PR DESCRIPTION
Closes #10 - This updates everything for 1.17, fixes downloads for goBrush and goPaint (now uses Jenkins), and also replaces Yatopia with Airplane.